### PR TITLE
fix rounding/conversion errors when currency converts to less than 100 sats

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -57,7 +57,7 @@ $( document ).ready(function() {
 			}
 			else if(source_currency == "usd" || source_currency == "eur" || source_currency == "gbp"){
 				console.log(RateToBTC[source_currency])
-				$btc_input.val(  parseFloat(source_val) / parseFloat(RateToBTC[source_currency]) );
+				$btc_input.val( parseFloat( parseFloat(source_val) / parseFloat(RateToBTC[source_currency]) ).toFixed(8) );
 			}
 
 			// Updates BTC value


### PR DESCRIPTION
When you convert a currency to BTC/sats and the resulting amount of sats is less than 100 sats, the resulting amount of BTC/sats (and currency)is incorrect. The amount of BTC is less than 1e-6 and conversion goes wrong and the exponent is removed from the result. The resulting conversion is 1M to high.

Adding a parseFloat().toFixed(8) fixes the issue.